### PR TITLE
Exclude spatial region from prov:Entity

### DIFF
--- a/PROV/prov-bfo-directmappings.ttl
+++ b/PROV/prov-bfo-directmappings.ttl
@@ -16,7 +16,19 @@
 .
 
 # Class mappings
-prov:Entity               rdfs:subClassOf obo:BFO_0000002 . # continuant
+# Entities are continuants, except for spatial regions (which are causally inert and may not participate in processes)
+prov:Entity               rdfs:subClassOf [ rdf:type owl:Class ;
+                                            owl:unionOf ( obo:BFO_0000020  # specifically dependent continuant
+                                                          obo:BFO_0000031  # generically dependent continuant
+                                                          [ owl:intersectionOf ( obo:BFO_0000004  # independent continuant
+                                                                                [ rdf:type owl:Class ;
+                                                                                  owl:complementOf obo:BFO_0000006  # spatial region
+                                                                                ]
+                                                                               ) ;
+                                                            rdf:type owl:Class ;
+                                                          ]
+                                                        )
+                                          ] . 
 prov:Agent                rdfs:subClassOf obo:BFO_0000040 . # material entity
 prov:Activity             rdfs:subClassOf obo:BFO_0000015 . # process
 prov:Role                 rdfs:subClassOf obo:BFO_0000034 . # function


### PR DESCRIPTION
* Any `prov:Entity` is some kind `bfo:continuant` but not a `bfo:spatial region`
* Based on Giacomo's nice summary here:
> Reminder: spatial regions are causally inert. They cannot participate in processes, as axiomatized in BFO. Thus, they are not suitable candidates for being PROV entities. We are considering to make PROV entity whatever can participate into a BFO:process (basically, all continuants besides spatial regions)